### PR TITLE
Remove push event for main branch in annotate and rubocop workflows

### DIFF
--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -1,8 +1,6 @@
 ---
 name: annotate
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,8 +1,6 @@
 ---
 name: rubocop
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
### Description

Removes the push event for the main branch in the `.github/workflows/annotate.yml` and `.github/workflows/rubocop.yml` files. This change ensures that the workflows will only run on pull requests targeting the main branch.