### PR TITLE
reorder dependencies of Gemfile following by Bundler/OrderedGems rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 ruby '3.2.2'
 source 'https://rubygems.org'
 gem 'annotate'
-gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt'
 gem 'byebug'
 gem 'draper'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  bcrypt (~> 3.1.7)
+  bcrypt
   byebug
   capybara
   draper


### PR DESCRIPTION
### Description

Modify the dependency rule for the bcrypt gem to avoid the hard-coding version.