### PR TITLE
Use secure cookies only when SSL is forced by app

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,7 @@ class SessionsController < ApplicationController # :nodoc:
     cookies.encrypted[:current_user] = {
       value: @session.email,
       expires: 1.hour,
-      secure: !(Rails.env.development? || Rails.env.test?),
+      secure: Rails.application.config.force_ssl,
       httponly: true,
       same_site: :strict
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,4 +2,5 @@
 
 Rails.application.configure do
   config.eager_load = false
+  config.force_ssl = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,4 +2,5 @@
 
 Rails.application.configure do
   config.eager_load = true
+  config.force_ssl = false
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,4 +2,5 @@
 
 Rails.application.configure do
   config.eager_load = false
+  config.force_ssl = false
 end


### PR DESCRIPTION
### Description

When `Rails.application.config.force_ssl` is true then the secure cookies should be used.