### PR TITLE
specify default port for postgresql production env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,6 @@ production:
   adapter: postgresql
   encoding: unicode
   pool: 3
-  port: 5412
+  port: 5432
   schema_search_path: 'public'
   database: support-ticker-system-production


### PR DESCRIPTION
### Description

specify `5432` as default postgresql port on the production env.